### PR TITLE
Changed the readme and the title bar to point to the correct URL for the test site

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ make serve
 ```
 
 You can then preview the site at
-[http://0.0.0.0:4000/software-carpentry-training-course/](http://0.0.0.0:4000/software-carpentry-training-course/).
+[http://0.0.0.0:4000/training-course/](http://0.0.0.0:4000/training-course/).

--- a/README.md
+++ b/README.md
@@ -25,4 +25,4 @@ make serve
 ```
 
 You can then preview the site at
-[http://0.0.0.0:4000/software-carpentry-training-website/](http://0.0.0.0:4000/software-carpentry-training-website/).
+[http://0.0.0.0:4000/software-carpentry-training-course/](http://0.0.0.0:4000/software-carpentry-training-course/).

--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -7,7 +7,7 @@
         <span class="icon-bar"></span>
         <span class="icon-bar"></span>
       </button>
-      <a class="navbar-brand" href="{{ site.baseurl }}">{{ site.title }}</a>
+      <a class="navbar-brand" href="{{ site.baseurl }}/">{{ site.title }}</a>
     </div>
     <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
       <ul class="nav navbar-nav">


### PR DESCRIPTION
The link in the README.sh was incorrect when serving the website locally, and when you click on the TEACHING SOFTWARE CARPENTRY svg, the link was broken because it was missing a terminating /.
