### PR TITLE
Fixed the concept map for pipes in bash

### DIFF
--- a/_submissions/round-12/1/2015-02-22-pipes-in-bash.md
+++ b/_submissions/round-12/1/2015-02-22-pipes-in-bash.md
@@ -11,6 +11,6 @@ tags:
 
 I created a concept map for part of the Shell lessons, specifically [pipes in bash](http://swcarpentry.github.io/shell-novice/03-pipefilter.html). In this map I've attempted to capture the purposes for using pipes as well as how they are used and what they are composed of. 
 
-![Concept map of pipes in bash](http://imgur.com/tbnRXWW)
+<a href="http://imgur.com/tbnRXWW.jpg"><img alt="Concept map of pipes in bash" src="http://imgur.com/tbnRXWW.jpg" width="500px"/></a>
 
 


### PR DESCRIPTION
The image was missing on the post. Changed from markdown images to using HTML tags directly since the image was so huge. Image is also clickable for convenience.
