### PR TITLE
fixed incorrect link to kris concept map

### DIFF
--- a/_submissions/round-12/1/2015-02-26-pipes-in-bash.md
+++ b/_submissions/round-12/1/2015-02-26-pipes-in-bash.md
@@ -13,4 +13,4 @@ A concept map for pipes in Bash, derived from the Software Carpentry lesson [Pip
 
 **To see comments, please view [this page](/training-course/2015/02/pipes-in-bash/)**.
 
-<a href="http://i.imgur.com/SefEK4O.jpg"><img src="http://i.imgur.com/HEJvwdl.jpg" title="Pipes in Bash Concept Map" /></a>
+<a href="http://i.imgur.com/SefEK4O.jpg"><img src="http://i.imgur.com/SefEK4O.jpg" title="Pipes in Bash Concept Map" /></a>


### PR DESCRIPTION
The <img> src attribute points to the incorrect concept map image.
