### PR TITLE
replaced incorrect image links with resized and correct image

### DIFF
--- a/_submissions/round-12/1/2015-02-26-pipes-in-bash.md
+++ b/_submissions/round-12/1/2015-02-26-pipes-in-bash.md
@@ -13,4 +13,4 @@ A concept map for pipes in Bash, derived from the Software Carpentry lesson [Pip
 
 **To see comments, please view [this page](/training-course/2015/02/pipes-in-bash/)**.
 
-<a href="http://i.imgur.com/SefEK4O.jpg"><img src="http://i.imgur.com/SefEK4O.jpg" title="Pipes in Bash Concept Map" /></a>
+<a href="http://i.imgur.com/qjNAtHd.png"><img src="http://i.imgur.com/qjNAtHd.png" title="Pipes in Bash Concept Map" /></a>

--- a/_submissions/round-12/1/2015-02-27-pipes-and-collisions.md
+++ b/_submissions/round-12/1/2015-02-27-pipes-and-collisions.md
@@ -18,7 +18,7 @@ Kristopher Keipert writes:
 
 A concept map for pipes in Bash, derived from the Software Carpentry lesson [Pipes and Filters](http://swcarpentry.github.io/shell-novice/03-pipefilter.html).
 
-<a href="http://i.imgur.com/SefEK4O.jpg"><img src="http://i.imgur.com/HEJvwdl.jpg" title="Pipes in Bash Concept Map" /></a>
+<a href="http://i.imgur.com/qjNAtHd.png"><img src="http://i.imgur.com/qjNAtHd.png" title="Pipes in Bash Concept Map" /></a>
 
 Greg Wilson writes:
 


### PR DESCRIPTION
I noticed the imgur links to my Bash pipes concept map on the redirect page are different, and the incorrect concept map is being displayed. Here I have replaced all imgur links with a new link to a resized image of the correct concept map.
