### PR TITLE
Change permalink to avoid conflict

### DIFF
--- a/_submissions/round-12/1/2015-02-23-pipes-and-filters.md
+++ b/_submissions/round-12/1/2015-02-23-pipes-and-filters.md
@@ -3,7 +3,7 @@ date: 2015-02-23
 round: Round 12
 title: Pipes and Filters Concept Map
 author: Daniel Wheeler
-permalink: /2015/02/pipes-and-filters/
+permalink: /2015/02/pipes-and-filters-wheeler/
 tags:
   - Concept Map
   - Pipes


### PR DESCRIPTION
Change related to #277

Both

https://github.com/swcarpentry/training-course/blob/611696b0afb2db681f5bb293925d6f70f6175154/_submissions/round-12/1/2015-02-23-pipes-and-filters.md

and

https://github.com/swcarpentry/training-course/blob/611696b0afb2db681f5bb293925d6f70f6175154/_submissions/round-12/1/2015-02-25-pipes-and-filters.md

have the same permalink. Included surname in permalink to distinguish.
