### PR TITLE
Adding a discussion page for Git, Github, and Markdown

### DIFF
--- a/_submissions/round-12/talkpage.md
+++ b/_submissions/round-12/talkpage.md
@@ -1,0 +1,48 @@
+---
+date: 2015-04-01
+round: Round 12
+title: Git, Github, and Markdown Talk Page for Instructor Round 12
+author: John Moreau
+permalink: /2015/04/Round12Talkpage
+tags:
+  - Git
+  - Github
+  - Markdown
+  
+---
+
+### Motivation 
+Many of us have had some difficulties with Git, Github, and Markdown. As anyone who's read my [demotivation post](http://swcarpentry.github.io/training-course/2015/03/john-moreau-motivation/) knows, I have definitely struggled with the tools. Since then I have received some helpful tutoring (thank you Ivan) and even more offers to help. That support has improved my motivation greatly. 
+ 
+While we build out our skills, each of us will come across key ideas that help us understand the tools better. I am posting this talk page so we can share those tips and tricks with each other along the way. Please feel free to add comments below or even add directly to the markdown file. As people add comments, I will incorporate their contributions into this text. 
+
+*Remember, if you had trouble with it, so did somebody else.*   
+
+
+### Git 
+- General principles you found confusing?
+- Tips for working on the commmand line?
+- Your comment here!
+
+
+### Github 
+- Did you have issues keeping your local machine in sync with the official repo?
+- Any suggestions on keeping branches neat?
+
+### Markdown
+- One thing that confused me about Markdown was that I didn't know you could edit a Markdown file with a plain text editor.
+- There are some markdown editors which show your formatted text next to your raw file.
+	- [MarkdownPad](http://markdownpad.com/) - (Windows) Wonderful side-by-side editor, with support for multiple flavors of Markdown.
+	- [DayOne](http://dayoneapp.com/) - (Mac/iOS) DayOne is a journal app that supports native Markdown. A great way to get some daily practice with Markdown. 
+	- Many other iOS text editors support Markdown. Do you have a favorite?
+- Here are some suggestions for plain text editors:
+	- [Notepad ++](http://notepad-plus-plus.org/) - (Windows) Great for multiple languages, including R, Python, and SQL.
+	- [Nano](http://www.nano-editor.org/download.php) - (Windows/Linux) Often used as a Vim alternative at bootcamps. Integrates nicely with Gitbash on windows.
+	- Add your Favorite Text Editor Here!
+
+
+If this page is missing something you think it should cover, let us know in the comments. Or better yet, make a pull request and add it to the page!
+
+
+
+ 


### PR DESCRIPTION
This pull request creates a talk page on the blog for people to discuss Git, Github, and Markdown. People can vent their frustrations, ask for help, and offer assistance. I know my markdown file is probably in the wrong location. I'm just excited that this worked smoothly. 
