### PR TITLE
fix permalink field adding trailing slash

### DIFF
--- a/_submissions/round-12/4/2015-04-15-jon-borrelli.md
+++ b/_submissions/round-12/4/2015-04-15-jon-borrelli.md
@@ -3,7 +3,7 @@ date: 2015-04-15
 round: Round 12
 title: Getting Info About Your Data in R
 author: Jon Borrelli
-permalink: /2015/04/jon-borrelli-video
+permalink: /2015/04/jon-borrelli-video/
 tags:
   - Practice Teaching
   - Video


### PR DESCRIPTION
Clicking on my post on the website downloaded a file. I think this is because the permalink did not end in /. So I changed that, hopefully this will make the post work. 
